### PR TITLE
Fix template and requirements for Django>=3.0

### DIFF
--- a/notebook/templates/notebook/bootstrap.html
+++ b/notebook/templates/notebook/bootstrap.html
@@ -1,4 +1,4 @@
-{% load staticfiles pipeline %}<!DOCTYPE html>
+{% load static pipeline %}<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django>=1.11.19
-django-pipeline==1.6.13
+django-pipeline>=1.6.13
 pypugjs==5.7.2


### PR DESCRIPTION
In case you want to pin django-pipeline to a specific version, `django-pipeline==2.0.4` works for me. However, considering that `Django` itself is not pinned to an exact version I'd recommend not to do that for `django-pipeline` either.